### PR TITLE
Fix parsing bug in ClassFileReader

### DIFF
--- a/src/main/java/jasm/io/ClassFileReader.java
+++ b/src/main/java/jasm/io/ClassFileReader.java
@@ -988,6 +988,9 @@ public final class ClassFileReader {
 			return new Bytecode.PutField(ont.first(), ont.second(),
 					ont.third(), mode);
 		}
+		case INSTANCEOF: {
+			return new Bytecode.InstanceOf((JvmType.Reference)type);
+		}
 		}
 
 		throw new RuntimeException(


### PR DESCRIPTION
Allow ClassFileReader to parse methods with instanceof expressions.